### PR TITLE
updates IdleProcessMetricsIT to verify config instead of set it.

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +35,6 @@ import org.apache.accumulo.test.metrics.TestStatsDRegistryFactory;
 import org.apache.accumulo.test.metrics.TestStatsDSink;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +47,7 @@ public class IdleProcessMetricsIT extends SharedMiniClusterBase {
 
       // Verify expectations about the default config. Want to ensure there no other resource groups
       // configured.
-      Assertions.assertEquals(Map.of(Constants.DEFAULT_COMPACTION_SERVICE_NAME, 1),
+      assertEquals(Map.of(Constants.DEFAULT_COMPACTION_SERVICE_NAME, 1),
           cfg.getClusterServerConfiguration().getCompactorConfiguration());
 
       // Disable the default scan servers and compactors, just start 1

--- a/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
@@ -32,6 +33,7 @@ import org.apache.accumulo.test.metrics.TestStatsDRegistryFactory;
 import org.apache.accumulo.test.metrics.TestStatsDSink;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -42,10 +44,10 @@ public class IdleProcessMetricsIT extends SharedMiniClusterBase {
     @Override
     public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
 
-      // Configure all compaction planners to use the default resource group so
-      // that only 1 compactor is started by MiniAccumuloCluster
-      cfg.setProperty(Property.COMPACTION_SERVICE_DEFAULT_GROUPS.getKey(),
-          "[{'group':'default'}]".replaceAll("'", "\""));
+      // Verify expectations about the default config. Want to ensure there no other resource groups
+      // configured.
+      Assertions.assertEquals(Map.of(Constants.DEFAULT_COMPACTION_SERVICE_NAME, 1),
+          cfg.getClusterServerConfiguration().getCompactorConfiguration());
 
       // Disable the default scan servers and compactors, just start 1
       // tablet server in the default group to host the root and metadata


### PR DESCRIPTION
pr_rerun QDinsight:fix-IdleProcessMetricsIT-2 to elasticity